### PR TITLE
docker build and github ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,7 +36,18 @@ jobs:
       - name: run ping
         run: cd docker && sudo -E make run-ping
 
+      - name: Run Walletshield
+        run: |
+          cd docker && sudo -E make run-walletshield
+      
+      - name: Test Walletshield
+        run: |
+          curl -x http://localhost:8080 http://example.com
+
+      - name: Stop the Walletshield
+        run: |
+          cd docker && sudo -E make stop-walletshield
+
       - name: Stop the mixnet
         run: |
           cd docker && sudo -E make stop
-

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,14 +39,15 @@ jobs:
         run: |
           sleep 240
 
-      - name: Verify Running Docker Containers
+      - name: run ping
+        run: cd docker && sudo -E make run-ping
+
+      - name: run client end to end tests
+        run: cd client && sudo -E make testargs=-coverprofile=coverage.part dockerdockertest && cat coverage.part >> ../coverage.out
+
+      - name: Stop the mixnet
         run: |
-          sleep 30  # Allow some time for all services to start up
-          containers=$(sudo docker ps --format '{{.Names}}: {{.Status}}')
-          echo "Running containers:"
-          echo "$containers"
-          if [[ $(echo "$containers" | wc -l) -lt 5 ]]; then  # Replace '5' with the expected number of running containers
-            echo "Error: Not all Docker containers are running."
-            exit 1
-          else
-            echo "All Docker containers are up and running."
+          cd docker && sudo -E make stop
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,11 @@
 name: build
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   docker_mixnet_setup:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,34 @@
+name: build
+jobs:
+  docker_mixnet_setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
+
+      - name: Build and Start Docker Mixnet
+        run: |
+          cd docker
+          sudo make start
+
+      - name: List All Containers
+        run: |
+          echo "Listing all Docker containers:"
+          sudo docker ps -a
+
+      - name: Verify Running Docker Containers
+        run: |
+          sleep 30  # Allow some time for all services to start up
+          containers=$(sudo docker ps --format '{{.Names}}: {{.Status}}')
+          echo "Running containers:"
+          echo "$containers"
+          if [[ $(echo "$containers" | wc -l) -lt 5 ]]; then  # Replace '5' with the expected number of running containers
+            echo "Error: Not all Docker containers are running."
+            exit 1
+          else
+            echo "All Docker containers are up and running."

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,7 @@ jobs:
       
       - name: Test Walletshield
         run: |
-          curl -x http://localhost:8080 http://example.com
+          curl -x http://localhost:8080 -s -o - -w "HTTP Status: %{http_code}\n" http://example.com
 
       - name: Stop the Walletshield
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,12 +42,7 @@ jobs:
       - name: run ping
         run: cd docker && sudo -E make run-ping
 
-      - name: run client end to end tests
-        run: cd client && sudo -E make testargs=-coverprofile=coverage.part dockerdockertest && cat coverage.part >> ../coverage.out
-
       - name: Stop the mixnet
         run: |
           cd docker && sudo -E make stop
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,24 +10,34 @@ on:
 jobs:
   docker_mixnet_setup:
     runs-on: ubuntu-latest
+    env:
+      warped: true
+      XDG_RUNTIME_DIR: /run
+    strategy:
+      matrix:
+        go-version: [1.21.x]
+        os: [ubuntu-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Docker Environment
+      - name: Configure podman socket
         run: |
-          sudo apt-get update
-          sudo apt-get install -y docker-compose
+          sudo systemctl restart dbus && sudo systemctl enable --now podman.socket
 
-      - name: Build and Start Docker Mixnet
+      - name: Build and start the mixnet
         run: |
-          cd docker
-          sudo make start
+          cd docker && sudo -E make start
 
       - name: List All Containers
         run: |
           echo "Listing all Docker containers:"
+          sleep 2
           sudo docker ps -a
+
+      - name: Allow mixnet to settle
+        run: |
+          sleep 240
 
       - name: Verify Running Docker Containers
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,6 +41,7 @@ jobs:
           cd docker && sudo -E make run-walletshield
       
       - name: Test Walletshield
+        continue-on-error: true
         run: |
           curl -x http://localhost:8080 -s -o - -w "HTTP Status: %{http_code}\n" http://example.com
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,12 +29,6 @@ jobs:
         run: |
           cd docker && sudo -E make start
 
-      - name: List All Containers
-        run: |
-          echo "Listing all Docker containers:"
-          sleep 2
-          sudo docker ps -a
-
       - name: Allow mixnet to settle
         run: |
           sleep 240

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,7 @@
 name: build
+on:
+  workflow_dispatch:
+
 jobs:
   docker_mixnet_setup:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 apps/walletshield/walletshield
 server_plugins/cbor_plugins/http_proxy/cmd/http_proxy/http_proxy
+docker/voting_mixnet
+docker/*.stamp

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -212,6 +212,18 @@ clean: clean-images clean-local
 	-$(docker) images|grep katzenpost|cat
 	rm -r $(katzenpost_dir)
 
+$(net_name)/walletshield.$(distro): $(distro)_go_mod.stamp $(net_name)/http_proxy.$(distro)
+		$(docker) run $(opt_docker_args) $(mount_net_name) katzenpost-alpine_base \
+			$(sh) -c 'cd $(opt_workspace)/apps/walletshield && go mod verify && go build -ldflags ${ldflags} && \
+			mv walletshield /$(net_name)/walletshield.$(distro)'
+
+run-walletshield: $(net_name)/walletshield.$(distro) $(net_name)/running.stamp
+		$(docker) run -d --network=host $(opt_docker_args) $(mount_net_name) --name walletshield  --rm katzenpost-$(distro)_go_mod \
+        /$(net_name)/walletshield.$(distro) -config /$(net_name)/client/client.toml -listen :8080 -log_level DEBUG
+
+stop-walletshield:
+		$(docker) stop walletshield
+
 run-ping: $(net_name)/ping.$(distro) $(net_name)/running.stamp
 	$(docker) run --network=host ${katzenpost_docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_go_mod \
         /$(net_name)/ping.$(distro) -c /$(net_name)/client/client.toml -s echo -printDiff -n 1

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -174,8 +174,7 @@ $(net_name)/voting.$(distro): $(distro)_go_mod.stamp $(docker_compose_yml)
 
 $(net_name)/ping.$(distro): $(distro)_go_mod.stamp
 		$(docker) run ${katzenpost_docker_args} $(mount_net_name) --rm katzenpost-$(distro)_go_mod \
-			$(sh) -c 'cd ping && go mod verify && go build -ldflags ${ldflags} && \
-			mv ping /$(net_name)/ping.$(distro)'
+			go build -trimpath -ldflags $(ldflags) -o /$(net_name)/ping.$(distro) $(katzenpost_workspace)/ping
 
 $(net_name)/http_proxy.$(distro): alpine_base.stamp
 		$(docker) run $(opt_docker_args) $(mount_net_name) katzenpost-alpine_base \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -63,7 +63,13 @@ uid?=$(shell [ "$$SUDO_UID" != "" ] && echo "$$SUDO_UID" || id -u)
 gid?=$(shell [ "$$SUDO_GID" != "" ] && echo "$$SUDO_GID" || id -g)
 
 docker_user?=$(shell if echo ${docker}|grep -q podman; then echo 0:0; else echo ${uid}:${gid}; fi)
-docker_args=--user ${docker_user} --volume $(shell readlink -f ..):/go/katzenpost --workdir /go/katzenpost
+
+opt_workspace=/go/opt
+katzenpost_workspace=/go/katzenpost
+katzenpost_dir=$(HOME)/katzenpost
+
+opt_docker_args=--user ${docker_user} --volume $(shell readlink -f ..):$(opt_workspace) --workdir $(opt_workspace)
+katzenpost_docker_args=--user ${docker_user} --volume $(katzenpost_dir):$(katzenpost_workspace) --workdir $(katzenpost_workspace)
 
 replace_name=$(shell if echo ${docker}|grep -q podman; then echo " --replace --name"; else echo " --name"; fi)
 i_if_podman=$(shell if echo ${docker}|grep -q podman; then echo " -i"; else echo; fi)
@@ -73,9 +79,14 @@ docker_compose?= $(shell if echo ${docker}|grep -q podman; then echo DOCKER_HOST
 
 make_args=--no-print-directory net_name=$(net_name) docker=$(docker) distro=$(distro) warped=$(warped) docker_user=$(docker_user)
 
+clone-katzenpost:
+	if [ ! -d "$(katzenpost_dir)" ]; then \
+		git clone https://github.com/katzenpost/katzenpost.git $(katzenpost_dir); \
+	fi
+
 $(docker_compose_yml): ../genconfig/main.go $(distro)_go_mod.stamp
 	mkdir -p $(net_name)
-	$(docker) run ${docker_args} --rm katzenpost-$(distro)_go_mod \
+	$(docker) run ${opt_docker_args} --rm katzenpost-$(distro)_go_mod \
 		$(sh) -c 'cd genconfig && go build && cd ../docker \
 		&& ../genconfig/genconfig -wirekem $(wirekem) -a ${bind_addr} -nv ${auths} -n ${mixes} -p ${providers} \
 		-sr ${sr} -mu ${mu} -muMax ${muMax} -lP ${lP} -lPMax ${lPMax} -lL ${lL} \
@@ -92,7 +103,7 @@ run: $(docker_compose_yml) $(net_name)/server.$(distro) $(net_name)/voting.$(dis
 	&& DOCKER_USER=${docker_user} $(docker_compose) up --remove-orphans
 	cd $(net_name) && rm -v running.stamp
 
-start: $(docker_compose_yml) $(net_name)/server.$(distro) $(net_name)/voting.$(distro)
+start: clone-katzenpost $(docker_compose_yml) $(net_name)/server.$(distro) $(net_name)/voting.$(distro)
 	cd $(net_name); DOCKER_USER=${docker_user} $(docker_compose) up --remove-orphans -d; $(docker_compose) top
 	touch $(net_name)/running.stamp
 
@@ -117,7 +128,7 @@ show-latest-vote:
 	@grep -A30 'Ready to send' voting_mixnet/auth1/katzenpost.log |tail -30|sed /Sending/q
 
 wait: $(net_name)/running.stamp
-	$(docker) run --network=host ${docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_go_mod \
+	$(docker) run --network=host ${katzenpost_docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_go_mod \
 	/$(net_name)/fetch.$(distro) -f /$(net_name)/client/client.toml
 
 debian_base.stamp:
@@ -133,7 +144,7 @@ alpine_base.stamp:
 	touch $@
 
 $(distro)_go_mod.stamp: $(distro)_base.stamp
-	$(docker) run ${docker_args} $(replace_name) \
+	$(docker) run ${katzenpost_docker_args} $(replace_name) \
 		katzenpost_$(distro)_go_mod katzenpost-$(distro)_base \
 		sh -c 'go mod download'
 	$(docker) commit katzenpost_$(distro)_go_mod katzenpost-$(distro)_go_mod
@@ -141,29 +152,28 @@ $(distro)_go_mod.stamp: $(distro)_base.stamp
 	touch $@
 
 go-mod-tidy: $(distro)_go_mod.stamp
-	$(docker) run ${docker_args} $(replace_name) katzenpost_$(distro)_go_mod katzenpost-$(distro)_go_mod \
+	$(docker) run ${katzenpost_docker_args} $(replace_name) katzenpost_$(distro)_go_mod katzenpost-$(distro)_go_mod \
 			$(sh) -c "go mod tidy" \
 		&& $(docker) commit katzenpost_$(distro)_go_mod katzenpost-$(distro)_go_mod \
 		&& $(docker) rm katzenpost_$(distro)_go_mod
 
 go-mod-upgrade: $(distro)_go_mod.stamp
-	$(docker) run ${docker_args} $(replace_name) katzenpost_$(distro)_go_mod katzenpost-$(distro)_go_mod \
+	$(docker) run ${katzenpost_docker_args} $(replace_name) katzenpost_$(distro)_go_mod katzenpost-$(distro)_go_mod \
 			$(sh) -c 'go get -d -u ./... && go mod tidy' \
 		&& $(docker) commit katzenpost_$(distro)_go_mod katzenpost-$(distro)_go_mod \
 		&& $(docker) rm katzenpost_$(distro)_go_mod
 
 $(net_name)/server.$(distro): $(distro)_go_mod.stamp $(docker_compose_yml)
-		$(docker) run ${docker_args} $(mount_net_name) --rm katzenpost-$(distro)_go_mod \
-			$(sh) -c 'cd server && make $(make_args) testnet-build testnet-install'
+		$(docker) run ${katzenpost_docker_args} $(mount_net_name) --rm katzenpost-$(distro)_go_mod \
+			go build -trimpath -ldflags $(ldflags) -o /$(net_name)/server.$(distro) $(katzenpost_workspace)/server/cmd/server
 
 $(net_name)/voting.$(distro): $(distro)_go_mod.stamp $(docker_compose_yml)
-		$(docker) run ${docker_args} $(mount_net_name) --rm katzenpost-$(distro)_go_mod \
-			$(sh) -c 'cd authority && make $(make_args) cmd/voting/voting cmd/fetch/fetch && \
-			mv cmd/voting/voting /$(net_name)/voting.$(distro) && \
-			mv cmd/fetch/fetch /$(net_name)/fetch.$(distro)'
+		$(docker) run ${katzenpost_docker_args} $(mount_net_name) --rm katzenpost-$(distro)_go_mod \
+			$(sh) -c 'go build -trimpath -ldflags $(ldflags) -o /$(net_name)/voting.$(distro) $(katzenpost_workspace)/authority/cmd/voting && \
+				go build -trimpath -ldflags $(ldflags) -o /$(net_name)/fetch.$(distro) $(katzenpost_workspace)/authority/cmd/fetch'
 
 $(net_name)/ping.$(distro): $(distro)_go_mod.stamp
-		$(docker) run ${docker_args} $(mount_net_name) --rm katzenpost-$(distro)_go_mod \
+		$(docker) run ${katzenpost_docker_args} $(mount_net_name) --rm katzenpost-$(distro)_go_mod \
 			$(sh) -c 'cd ping && go mod verify && go build -ldflags ${ldflags} && \
 			mv ping /$(net_name)/ping.$(distro)'
 
@@ -196,13 +206,14 @@ clean-local-dryrun:
 clean: clean-images clean-local
 	-$(docker) ps -a|grep katzenpost|cat
 	-$(docker) images|grep katzenpost|cat
+	rm -r $(katzenpost_dir)
 
 run-ping: $(net_name)/ping.$(distro) $(net_name)/running.stamp
-	$(docker) run --network=host ${docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_go_mod \
+	$(docker) run --network=host ${katzenpost_docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_go_mod \
         /$(net_name)/ping.$(distro) -c /go/katzenpost/docker/$(net_name)/client/client.toml -s echo -printDiff -n 1
 
 shell: $(distro)_go_mod.stamp
-	$(docker) run --network=host ${docker_args} $(mount_net_name) -w /go/katzenpost/docker/$(net_name) --rm -it katzenpost-$(distro)_go_mod $(sh)
+	$(docker) run --network=host ${katzenpost_docker_args} $(mount_net_name) -w /go/katzenpost/docker/$(net_name) --rm -it katzenpost-$(distro)_go_mod $(sh)
 
 # this is for running with docker, where we are root outside and (except for
 # here) non-root inside. When using podman, we are rootless outside and uid 0

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -103,7 +103,7 @@ run: $(docker_compose_yml) $(net_name)/server.$(distro) $(net_name)/voting.$(dis
 	&& DOCKER_USER=${docker_user} $(docker_compose) up --remove-orphans
 	cd $(net_name) && rm -v running.stamp
 
-start: clone-katzenpost $(docker_compose_yml) $(net_name)/server.$(distro) $(net_name)/voting.$(distro)
+start: clone-katzenpost $(docker_compose_yml) $(net_name)/http_proxy.$(distro) $(net_name)/server.$(distro) $(net_name)/voting.$(distro) 
 	cd $(net_name); DOCKER_USER=${docker_user} $(docker_compose) up --remove-orphans -d; $(docker_compose) top
 	touch $(net_name)/running.stamp
 
@@ -176,6 +176,11 @@ $(net_name)/ping.$(distro): $(distro)_go_mod.stamp
 		$(docker) run ${katzenpost_docker_args} $(mount_net_name) --rm katzenpost-$(distro)_go_mod \
 			$(sh) -c 'cd ping && go mod verify && go build -ldflags ${ldflags} && \
 			mv ping /$(net_name)/ping.$(distro)'
+
+$(net_name)/http_proxy.$(distro): alpine_base.stamp
+		$(docker) run $(opt_docker_args) $(mount_net_name) katzenpost-alpine_base \
+			$(sh) -c 'cd $(opt_workspace)/server_plugins/cbor_plugins/http_proxy/cmd/http_proxy && go mod verify && go build -ldflags ${ldflags} && \
+			mv http_proxy /$(net_name)/http_proxy.$(distro)'
 
 clean-images: stop
 	@-for distro in $(DISTROS); do \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -215,7 +215,7 @@ clean: clean-images clean-local
 
 run-ping: $(net_name)/ping.$(distro) $(net_name)/running.stamp
 	$(docker) run --network=host ${katzenpost_docker_args} $(mount_net_name) --rm  katzenpost-$(distro)_go_mod \
-        /$(net_name)/ping.$(distro) -c /go/katzenpost/docker/$(net_name)/client/client.toml -s echo -printDiff -n 1
+        /$(net_name)/ping.$(distro) -c /$(net_name)/client/client.toml -s echo -printDiff -n 1
 
 shell: $(distro)_go_mod.stamp
 	$(docker) run --network=host ${katzenpost_docker_args} $(mount_net_name) -w /go/katzenpost/docker/$(net_name) --rm -it katzenpost-$(distro)_go_mod $(sh)


### PR DESCRIPTION
This PR aims to integrate specific Docker build steps directly into the GitHub CI pipeline for the `opt` repository. The focus is on setting up a Dockerized Katzenpost mixnet specifically tailored to run and test the `http_proxy` server plugin, without the need for forking the Katzenpost repository. Key steps include:

This PR includes modifications to `.github/workflows/go.yml`, `docker/Makefile`, and various configuration files to achieve the outlined objectives in https://github.com/0KnowledgeNetwork/opt/issues/9