### PR TITLE
feat: add walletshield+http_proxy probe

### DIFF
--- a/server_plugins/cbor_plugins/http_proxy/cmd/http_proxy/main.go
+++ b/server_plugins/cbor_plugins/http_proxy/cmd/http_proxy/main.go
@@ -146,6 +146,13 @@ func (s *proxyRequestHandler) OnCommand(cmd cborplugin.Command) error {
 			return fmt.Errorf("validateRequestURL failed: %s", err)
 		}
 
+		if request.URL.Path == "/_/probe" {
+			go func() {
+				s.write(&cborplugin.Response{ID: r.ID, SURB: r.SURB, Payload: nil})
+			}()
+			return nil
+		}
+
 		uri := request.URL.Path
 		uri = uri[1:]
 		target, ok := s.cfg.Networks[uri]


### PR DESCRIPTION
For client testing. Add an option instructing walletshield to send a test request instead of listening for http requests on a port. Add a URL endpoint instructing http_proxy to reply immediately to the test request.